### PR TITLE
Fix C++ BeaEngineVersion and BeaEngineRevision declarations

### DIFF
--- a/headers/BeaEngine.h
+++ b/headers/BeaEngine.h
@@ -310,10 +310,15 @@ enum SPECIAL_INFO
 
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 
 BEA_API int __bea_callspec__ Disasm (LPDISASM pDisAsm);
 BEA_API const__ char* __bea_callspec__ BeaEngineVersion (void);
 BEA_API const__ char* __bea_callspec__ BeaEngineRevision (void);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/include/beaengine/BeaEngine.h
+++ b/include/beaengine/BeaEngine.h
@@ -370,12 +370,18 @@ enum SPECIAL_INFO
 
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 
 BEA_API int __bea_callspec__ Disasm (LPDISASM pDisAsm);
 BEA_API const__ char* __bea_callspec__ BeaEngineVersion (void);
 BEA_API const__ char* __bea_callspec__ BeaEngineRevision (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+
 #if  defined(__cplusplus) && defined(__BORLANDC__)
 };
 using namespace BeaEngine;


### PR DESCRIPTION
It was impossible to call BeaEngineVersion() and  BeaEngineRevision().

Hotfix is:
```
extern "C" {
#include <BeaEngine.h>
}
```