### PR TITLE
Fixes typo (Uint64 -> UInt64) that breaks Windows compilation on Mingw

### DIFF
--- a/headers/BeaEngine.h
+++ b/headers/BeaEngine.h
@@ -93,7 +93,7 @@ typedef struct  {
 #pragma pack(1)
 typedef struct  {
    char ArgMnemonic[24];
-   Uint64 ArgType;
+   UInt64 ArgType;
    Int32 ArgSize;
    Int32 ArgPosition;
    UInt32 AccessMode;

--- a/headers/BeaEnginePython.py
+++ b/headers/BeaEnginePython.py
@@ -341,3 +341,5 @@ elif os.name == 'posix':
 Disasm = __module.Disasm
 BeaEngineVersion = __module.BeaEngineVersion
 BeaEngineRevision = __module.BeaEngineRevision
+BeaEngineVersion.restype = c_char_p
+BeaEngineRevision.restype = c_char_p


### PR DESCRIPTION
Seems to be a typo. When I cmake a Code::Blocks project w/ mingw, gcc complains, so here's a fix.