### PR TITLE
Cmake MSVC improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 headers/libBeaEngine.so
 **.pyc
 lib
+bin
 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,14 +121,21 @@ if (BEA_COMPILER STREQUAL msvc)
 		set (BEA_WARNINGS /W4)
 	endif ()
   endif ()
-  if (optHAS_SYMBOLS)
-    list (APPEND BEA_FLAGS /ZI)
-  endif ()
+
+  list (APPEND BEA_FLAGS /Zi)
+
   if (optHAS_OPTIMIZED)
     list (APPEND BEA_FLAGS /O2)
     list (APPEND BEA_DEFINITIONS "/DNDEBUG")
   else ()
     list (APPEND BEA_DEFINITIONS "/D_DEBUG")
+  endif ()
+
+  #generate PDB for Debug/RelWithDebInfo builds
+  if (optHAS_SYMBOLS)
+    if (optBUILD_DLL)
+      set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG /OPT:REF,ICF")
+    endif ()
   endif ()
 
   # determine code generation model
@@ -306,7 +313,6 @@ if (${CMAKE_BUILD_TYPE} STREQUAL Debug)
   set (CMAKE_C_FLAGS_DEBUG   ${myC_FLAGS})
   set (CMAKE_CXX_FLAGS_DEBUG ${myCXX_FLAGS})
 endif ()
-
 
 set (BEA_INCLUDE_PATH ${CMAKE_SOURCE_DIR}/include)
 set (BEA_SRC_ROOT ${CMAKE_SOURCE_DIR}/src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,10 @@ if (NOT optHAS_OPTIMIZED)
   set (BEA_TARGET "${BEA_TARGET}_d")
 endif ()
 
+if (NOT optBUILD_LITE)
+  set (BEA_TARGET "${BEA_TARGET}_l")
+endif ()
+
 if (optBUILD_STDCALL)
   set (BEA_TARGET "${BEA_TARGET}_stdcall")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,11 +123,12 @@ if (BEA_COMPILER STREQUAL msvc)
   endif ()
   if (optHAS_SYMBOLS)
     list (APPEND BEA_FLAGS /ZI)
-	list (APPEND BEA_DEFINITIONS "/D_DEBUG=1")
   endif ()
   if (optHAS_OPTIMIZED)
     list (APPEND BEA_FLAGS /O2)
     list (APPEND BEA_DEFINITIONS "/DNDEBUG")
+  else ()
+    list (APPEND BEA_DEFINITIONS "/D_DEBUG")
   endif ()
 
   # determine code generation model


### PR DESCRIPTION
This fix contains some simple improvements to make MSVC build predictable:
1. Add separate suffix for lite version - important when you need to compile full and lite;
2. Fix `_DEBUG` define generation
3. Enable PDB generation for release builds, see [Correctly Creating Native C++ Release Build PDBs](http://www.wintellect.com/devcenter/jrobbins/correctly-creating-native-c-release-build-pdbs)
